### PR TITLE
fix(generator): anchor choice weight regex to end of string

### DIFF
--- a/py/generator.py
+++ b/py/generator.py
@@ -173,7 +173,7 @@ def _split_top_level_pipes(s: str) -> list[str]:
 
 # ------------------------ Weighted file helpers -----------------------------
 
-_WEIGHT_RE = re.compile(r'(?<!\\)%([0-9]*\.?[0-9]+)')
+_WEIGHT_RE = re.compile(r'(?<!\\)%([0-9]*\.?[0-9]+)(?=\s*$)')
 
 def _extract_choice_weight(choice: str) -> tuple[str, float]:
     """


### PR DESCRIPTION
This change fixes a regression introduced in 9c99cf02b3415e6851ad02e359f869d2b043ff32 where nested prompts with weights were incorrectly parsed.

Previously, the weight regex `_WEIGHT_RE` would match any percentage number sequence within the string. This caused issues when nested structures contained their own weights, leading to the parent parser incorrectly consuming or modifying the inner weights.

For example, a nested prompt like `{%7|cover image%3}%8` could be evaluated to `cover image %8` because of loose matching.

The regex has been updated to include `(?=\s*$)`, ensuring that a weight is only recognized if it appears at the very end of the choice string (ignoring trailing whitespace).

Fixes #10 