### PR TITLE
Add space in FILE_PATTERN to resolve spaces in directories & wildcard files

### DIFF
--- a/py/generator.py
+++ b/py/generator.py
@@ -21,7 +21,7 @@ BRACKET_PATTERN = re.compile(r"\{([^{}]+)\}")
 # - name may include letters/digits/_/-/* and '/'
 # - optional ^var after the name (var may include trailing *)
 # - also supports pure variable recall: __^var__
-FILE_PATTERN = re.compile(r"__(?:([a-zA-Z0-9_\-/*]+?))?(?:\^([a-zA-Z0-9_\-\*]+))?__")
+FILE_PATTERN = re.compile(r"__(?:([a-zA-Z0-9_\-/ *]+?))?(?:\^([a-zA-Z0-9_\-\*]+))?__")
 
 # Normalize spacing between adjacent wildcard-ish tokens (allow ^ and *)
 ADJ_WC_PATTERN = re.compile(r"(__[a-zA-Z0-9_\-/*\^\*]+__)(__[a-zA-Z0-9_\-/*\^\*]+__)")

--- a/py/prompt_sequencer.py
+++ b/py/prompt_sequencer.py
@@ -15,7 +15,7 @@ from typing import List, Tuple
 from .wildcard_utils import build_category_options, _default_package_root
 
 # Regex to recognize __file__ and optional ^var (we ignore ^var in sequencing)
-FILE_PATTERN = re.compile(r"__(?:([a-zA-Z0-9_\-/*]+?))?(?:\^([a-zA-Z0-9_\-\*]+))?__")
+FILE_PATTERN = re.compile(r"__(?:([a-zA-Z0-9_\-/ *]+?))?(?:\^([a-zA-Z0-9_\-\*]+))?__")
 
 # Reused helper: split top-level pipes inside braces (preserve exact segments)
 def _split_top_level_pipes(s: str) -> List[str]:


### PR DESCRIPTION
In short, I tested with copying https://github.com/adieyal/sd-dynamic-prompts/tree/main/collections/artists to the `wildcard_artists` directory within `comfyui-adaptiveprompts`, and noticed spaces in directories or files themselves wouldn't resolve:

<img width="1037" height="358" alt="Screenshot 2026-02-04 at 13 58 06" src="https://github.com/user-attachments/assets/984b1dd6-0c40-4d2c-8a4a-11560ae7bc54" />

[yoga.txt](https://github.com/adieyal/sd-dynamic-prompts/blob/main/collections/artists/Japanese%20Art/yoga/yoga.txt):
```
__artists/Japanese Art/yoga/meiji_era__
__artists/Japanese Art/yoga/taisho_era__
```

Added a space to `FILE_PATTERN` in `py/generator.py`:

<img width="1032" height="336" alt="Screenshot 2026-02-04 at 13 54 05" src="https://github.com/user-attachments/assets/e777684d-7068-4ae5-a511-ecaacce1eb22" />

Tested a few iterative runs with your demo workflow, and didn't spot any regression elsewhere (but that doesn't mean there isn't any, its .. finicky it seems). 

Anyway, thanks for your work, hopefully this helps :-)